### PR TITLE
Add filtering to performance comparisons

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "chai": "^3.4.1",
     "fs-extra": "^0.26.2",
     "fs-generate": "^1.0.0",
+    "glob": "^6.0.1",
     "mocha": "^2.3.4",
+    "readdirp": "^2.0.0",
     "sinon": "^1.17.2",
     "sinon-chai": "^2.8.0"
   }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "fs-extra": "^0.26.2",
     "fs-generate": "^1.0.0",
     "glob": "^6.0.1",
+    "micromatch": "^2.3.5",
     "mocha": "^2.3.4",
     "readdirp": "^2.0.0",
     "sinon": "^1.17.2",

--- a/perf/run-directory.js
+++ b/perf/run-directory.js
@@ -4,6 +4,8 @@ var Benchmark = require('benchmark');
 var walk = require('..');
 var fs = require('fs');
 var gfs = require('graceful-fs');
+var readdirp = require('readdirp');
+var glob = require('glob');
 
 var eachSerial = require('async-each-series');
 var serialOptionsFn = function(fs) { return {fs: fs, each: eachSerial}; }
@@ -53,6 +55,17 @@ module.exports = function(dir, callback) {
     }, {defer: true})
     .add('Parallel limit (gfs, 100)', function(deferred) {
       walk(dir, function() {}, parallelLimitOptionsFn(gfs, 100), function(err) { err ? deferred.reject() : deferred.resolve();});
+    }, {defer: true})
+
+    .add('readdirp', function(deferred) {
+      readdirp({root: dir})
+        .on('error', function() {deferred.reject()})
+        .on('data', Function.prototype)
+        .on('end', function() {deferred.resolve()});
+    }, {defer: true})
+
+    .add('glob', function(deferred) {
+      glob(dir + '/**/*', function(err) { err ? deferred.reject() : deferred.resolve();});
     }, {defer: true})
 
     .on('start', function() { console.log('Comparing ' + this.name); })

--- a/perf/run-directory.js
+++ b/perf/run-directory.js
@@ -6,66 +6,90 @@ var fs = require('fs');
 var gfs = require('graceful-fs');
 var readdirp = require('readdirp');
 var glob = require('glob');
+var micromatch = require('micromatch');
+var objectAssign = require('object-assign');
 
 var eachSerial = require('async-each-series');
-var serialOptionsFn = function(fs) { return {fs: fs, each: eachSerial}; }
-
 var eachParallel = require('async-each');
-var paralleOptionsFn = function(fs) { return {fs: fs, each: eachParallel}; }
-
 var eachlimit = require('each-limit');
-var parallelLimitOptionsFn = function(fs, limit) {
-  return {fs: fs, each: function(array, fn, callback) { eachlimit(array, limit, fn, callback); }};
-}
 
-module.exports = function(dir, callback) {
+module.exports = function(dir, pattern, callback) {
+  pattern = pattern || '';
+
   var relativeDir = dir.replace(sysPath.resolve(sysPath.join(__dirname, '..', '..')) + '/', '');
+  var filter = function() {};
 
-  new Benchmark.Suite('Walk ' + relativeDir)
+  if (pattern) {
+    var matcher = micromatch.matcher(pattern);
+    var hasGlobstar = pattern.indexOf('**') > -1;
+    filter = function(path, stat) {
+      if (hasGlobstar && stat && stat.isDirectory()) return true;
+      return matcher(path);
+    }
+  }
+
+  var defaultOpts = {includeStat: !!pattern};
+
+  var serialOptionsFn = function(fs) {
+    return objectAssign(defaultOpts, {fs: fs, each: eachSerial});
+  }
+
+  var paralleOptionsFn = function(fs) {
+    return objectAssign(defaultOpts, {fs: fs, each: eachParallel});
+  }
+
+  var parallelLimitOptionsFn = function(fs, limit) {
+    return objectAssign(defaultOpts, {
+      fs: fs,
+      each: function(array, fn, callback) { eachlimit(array, limit, fn, callback); }
+    });
+  }
+
+  new Benchmark.Suite('Walk ' + sysPath.join(relativeDir, pattern))
     .add('Default options', function(deferred) {
-      walk(dir, function() {}, function(err) { err ? deferred.reject() : deferred.resolve();});
+      walk(dir, filter, defaultOpts, function(err) { err ? deferred.reject() : deferred.resolve();});
     }, {defer: true})
 
     .add('Serial (fs)', function(deferred) {
-      walk(dir, function() {}, serialOptionsFn(fs), function(err) { err ? deferred.reject() : deferred.resolve();});
+      walk(dir, filter, serialOptionsFn(fs), function(err) { err ? deferred.reject() : deferred.resolve();});
     }, {defer: true})
 
     .add('Parallel (fs)', function(deferred) {
-      walk(dir, function() {}, paralleOptionsFn(fs), function(err) { err ? deferred.reject() : deferred.resolve();});
+      walk(dir, filter, paralleOptionsFn(fs), function(err) { err ? deferred.reject() : deferred.resolve();});
     }, {defer: true})
     .add('Parallel (gfs)', function(deferred) {
-      walk(dir, function() {}, paralleOptionsFn(gfs), function(err) { err ? deferred.reject() : deferred.resolve();});
+      walk(dir, filter, paralleOptionsFn(gfs), function(err) { err ? deferred.reject() : deferred.resolve();});
     }, {defer: true})
 
     .add('Parallel limit (fs, 10)', function(deferred) {
-      walk(dir, function() {}, parallelLimitOptionsFn(fs, 10), function(err) { err ? deferred.reject() : deferred.resolve();});
+      walk(dir, filter, parallelLimitOptionsFn(fs, 10), function(err) { err ? deferred.reject() : deferred.resolve();});
     }, {defer: true})
     .add('Parallel limit (fs, 50)', function(deferred) {
-      walk(dir, function() {}, parallelLimitOptionsFn(fs, 50), function(err) { err ? deferred.reject() : deferred.resolve();});
+      walk(dir, filter, parallelLimitOptionsFn(fs, 50), function(err) { err ? deferred.reject() : deferred.resolve();});
     }, {defer: true})
     .add('Parallel limit (fs, 100)', function(deferred) {
-      walk(dir, function() {}, parallelLimitOptionsFn(fs, 100), function(err) { err ? deferred.reject() : deferred.resolve();});
+      walk(dir, filter, parallelLimitOptionsFn(fs, 100), function(err) { err ? deferred.reject() : deferred.resolve();});
     }, {defer: true})
 
     .add('Parallel limit (gfs, 10)', function(deferred) {
-      walk(dir, function() {}, parallelLimitOptionsFn(gfs, 10), function(err) { err ? deferred.reject() : deferred.resolve();});
+      walk(dir, filter, parallelLimitOptionsFn(gfs, 10), function(err) { err ? deferred.reject() : deferred.resolve();});
     }, {defer: true})
     .add('Parallel limit (gfs, 50)', function(deferred) {
-      walk(dir, function() {}, parallelLimitOptionsFn(gfs, 50), function(err) { err ? deferred.reject() : deferred.resolve();});
+      walk(dir, filter, parallelLimitOptionsFn(gfs, 50), function(err) { err ? deferred.reject() : deferred.resolve();});
     }, {defer: true})
     .add('Parallel limit (gfs, 100)', function(deferred) {
-      walk(dir, function() {}, parallelLimitOptionsFn(gfs, 100), function(err) { err ? deferred.reject() : deferred.resolve();});
+      walk(dir, filter, parallelLimitOptionsFn(gfs, 100), function(err) { err ? deferred.reject() : deferred.resolve();});
     }, {defer: true})
 
     .add('readdirp', function(deferred) {
-      readdirp({root: dir})
+      readdirp({root: dir, filter: pattern})
         .on('error', function() {deferred.reject()})
         .on('data', Function.prototype)
         .on('end', function() {deferred.resolve()});
     }, {defer: true})
 
     .add('glob', function(deferred) {
-      glob(dir + '/**/*', function(err) { err ? deferred.reject() : deferred.resolve();});
+      glob(sysPath.join(dir, pattern || '/**/*'), function(err) { err ? deferred.reject() : deferred.resolve();});
     }, {defer: true})
 
     .on('start', function() { console.log('Comparing ' + this.name); })

--- a/perf/tests.js
+++ b/perf/tests.js
@@ -1,5 +1,6 @@
 var sysPath = require('path');
 
 var DIR = sysPath.resolve(sysPath.join(__dirname, '..', 'node_modules'));
+var PATTERN = '**/*.js';
 
-require('./run-directory')(DIR);
+require('./run-directory')(DIR, PATTERN);


### PR DESCRIPTION
Don't know whether you'll want this in master, but here's a quick pass at adding some degree of utilizing glob filtering to the benchmarks.

These are the results I got:

```
// PATTERN = '**/*.js'

Comparing Walk walk-filtered/node_modules/**/*.js
Default options x 20.01 ops/sec ±1.54% (52 runs sampled)
Serial (fs) x 9.74 ops/sec ±0.62% (50 runs sampled)
Parallel (fs) x 20.36 ops/sec ±0.79% (57 runs sampled)
Parallel (gfs) x 20.31 ops/sec ±0.76% (52 runs sampled)
Parallel limit (fs, 10) x 19.63 ops/sec ±0.63% (50 runs sampled)
Parallel limit (fs, 50) x 20.49 ops/sec ±0.69% (53 runs sampled)
Parallel limit (fs, 100) x 20.63 ops/sec ±0.74% (54 runs sampled)
Parallel limit (gfs, 10) x 19.40 ops/sec ±0.61% (50 runs sampled)
Parallel limit (gfs, 50) x 20.25 ops/sec ±0.69% (52 runs sampled)
Parallel limit (gfs, 100) x 20.11 ops/sec ±0.69% (52 runs sampled)
readdirp x 18.76 ops/sec ±1.95% (60 runs sampled)
glob x 18.38 ops/sec ±1.55% (88 runs sampled)
Fastest is Parallel limit (fs, 100),Parallel limit (fs, 50)
```

```
// PATTERN = false

Comparing Walk walk-filtered/node_modules
Default options x 20.60 ops/sec ±1.81% (53 runs sampled)
Serial (fs) x 10.18 ops/sec ±0.46% (52 runs sampled)
Parallel (fs) x 21.11 ops/sec ±0.74% (54 runs sampled)
Parallel (gfs) x 20.76 ops/sec ±0.75% (53 runs sampled)
Parallel limit (fs, 10) x 20.33 ops/sec ±0.70% (52 runs sampled)
Parallel limit (fs, 50) x 20.95 ops/sec ±0.87% (54 runs sampled)
Parallel limit (fs, 100) x 21.16 ops/sec ±0.92% (54 runs sampled)
Parallel limit (gfs, 10) x 19.80 ops/sec ±0.62% (51 runs sampled)
Parallel limit (gfs, 50) x 20.76 ops/sec ±0.75% (53 runs sampled)
Parallel limit (gfs, 100) x 20.79 ops/sec ±0.59% (53 runs sampled)
readdirp x 19.41 ops/sec ±2.04% (51 runs sampled)
glob x 14.03 ops/sec ±1.19% (70 runs sampled)
Fastest is Parallel limit (fs, 100),Parallel (fs)
```
